### PR TITLE
fix(Update toRoundedUnit to properly round negative values)

### DIFF
--- a/src/dinero.js
+++ b/src/dinero.js
@@ -574,8 +574,12 @@ const Dinero = options => {
      */
     toRoundedUnit(precision) {
       const factor = Math.pow(10, precision)
+
       return calculator.divide(
-        Math.round(calculator.multiply(this.toUnit(), factor)),
+        calculator.multiply(
+          Math.sign(this.toUnit()),
+          Math.round(Math.abs(calculator.multiply(this.toUnit(), factor)))
+        ),
         factor
       )
     },

--- a/test/unit/dinero.spec.js
+++ b/test/unit/dinero.spec.js
@@ -374,6 +374,7 @@ describe('Dinero', () => {
   describe('#toRoundedUnit()', () => {
     test('should return the amount divided by 100, rounded to one fraction digit', () => {
       expect(Dinero({ amount: 1055 }).toRoundedUnit(1)).toBe(10.6)
+      expect(Dinero({ amount: -1055 }).toRoundedUnit(1)).toBe(-10.6)
     })
   })
   describe('#toObject()', () => {


### PR DESCRIPTION
Math.round() doesn't correctly round negative values so this change first rounds the absolute value of the given amount and then multiplies in the Math.sign() afterwards.

This is my first contribution so happy for any feedback and change requests.

fix #7