### PR TITLE
fix(dinero): Round intermediate divide and multiply calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "jest": "^22.4.3",
     "jsdoc": "^3.5.5",
     "jsdoc-template": "sarahdayan/jsdoc-template",
+    "jsverify": "^0.8.3",
     "lint-staged": "^7.0.0",
     "prettier": "1.11.1",
     "rollup": "^0.57.1",

--- a/src/dinero.js
+++ b/src/dinero.js
@@ -193,33 +193,47 @@ const Dinero = options => {
     /**
      * Returns a new Dinero object that represents the multiplied value by the given factor.
      *
+     * [Banker's rounding](http://wiki.c2.com/?BankersRounding) is used to handle fractional cents.
+     * This *can* lead to accuracy issues as you chain many times. Consider a minimal amount of subsequent calculations for safer results.
+     *
      * @param  {Number} multiplier - The factor to multiply by.
      *
      * @example
      * // returns a Dinero object with amount 1600
      * Dinero({ amount: 400 }).multiply(4)
+     * // returns a Dinero object with amount 800
+     * Dinero({ amount: 400 }).multiply(2.001)
      *
      * @return {Dinero}
      */
     multiply(multiplier) {
       return create.call(this, {
-        amount: calculator.multiply(this.getAmount(), multiplier)
+        amount: calculator.bankersRound(
+          calculator.multiply(this.getAmount(), multiplier)
+        )
       })
     },
     /**
      * Returns a new Dinero object that represents the divided value by the given factor.
+     *
+     * [Banker's rounding](http://wiki.c2.com/?BankersRounding) is used to handle fractional cents.
+     * This *can* lead to accuracy issues as you chain many times. Consider a minimal amount of subsequent calculations for safer results.
      *
      * @param  {Number} divisor - The factor to divide by.
      *
      * @example
      * // returns a Dinero object with amount 100
      * Dinero({ amount: 400 }).divide(4)
+     * // returns a Dinero object with amount 52
+     * Dinero({ amount: 105 }).divide(2)
      *
      * @return {Dinero}
      */
     divide(divisor) {
       return create.call(this, {
-        amount: calculator.divide(this.getAmount(), divisor)
+        amount: calculator.bankersRound(
+          calculator.divide(this.getAmount(), divisor)
+        )
       })
     },
     /**

--- a/src/services/calculator.js
+++ b/src/services/calculator.js
@@ -1,3 +1,5 @@
+import { isEven } from './helpers'
+
 export default function Calculator() {
   return {
     /**
@@ -59,6 +61,21 @@ export default function Calculator() {
      */
     modulo(a, b) {
       return a % b
+    },
+    /**
+     * Returns a rounded number where if the input number is equidistant from the
+     * two nearest integers it is rounded to the nearest even integer.
+     * @ignore
+     *
+     * @param  {Number} value - The number to round.
+     *
+     * @return {Number}
+     */
+    bankersRound(value) {
+      const rounded = Math.round(value)
+      return Math.abs(value) % 1 === 0.5
+        ? isEven(rounded) ? rounded : rounded - 1
+        : rounded
     }
   }
 }

--- a/src/services/helpers.js
+++ b/src/services/helpers.js
@@ -9,3 +9,15 @@
 export function isNumeric(value) {
   return !isNaN(parseInt(value)) && isFinite(value)
 }
+
+/**
+ * Returns whether a value is even.
+ * @ignore
+ *
+ * @param  {Number} value - The value to test.
+ *
+ * @return {Boolean}
+ */
+export function isEven(value) {
+  return value % 2 === 0
+}

--- a/test/property/dinero.spec.js
+++ b/test/property/dinero.spec.js
@@ -1,0 +1,157 @@
+import Dinero from '../../src/dinero'
+import jsc from 'jsverify'
+
+describe('Dinero', () => {
+  describe('#add()', () => {
+    test('should be commutative', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.record({ amount: jsc.integer }),
+          jsc.record({ amount: jsc.integer }),
+          (a, b) =>
+            Dinero(a)
+              .add(Dinero(b))
+              .getAmount() ===
+            Dinero(b)
+              .add(Dinero(a))
+              .getAmount()
+        )
+      )
+    })
+    test('should be associative', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.record({ amount: jsc.integer }),
+          jsc.record({ amount: jsc.integer }),
+          jsc.record({ amount: jsc.integer }),
+          (a, b, c) =>
+            Dinero(a)
+              .add(Dinero(b))
+              .add(Dinero(c))
+              .getAmount() ===
+            Dinero(b)
+              .add(Dinero(a).add(Dinero(c)))
+              .getAmount()
+        )
+      )
+    })
+    test('should be distributive with integers', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.integer,
+          jsc.record({ amount: jsc.integer }),
+          jsc.record({ amount: jsc.integer }),
+          (a, b, c) =>
+            Dinero(b)
+              .add(Dinero(c))
+              .multiply(a)
+              .getAmount() ===
+            Dinero(b)
+              .multiply(a)
+              .add(Dinero(c).multiply(a))
+              .getAmount()
+        )
+      )
+    })
+  })
+  describe('#multiply()', () => {
+    test('should be commutative', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.integer,
+          jsc.integer,
+          (a, b) =>
+            Dinero({ amount: a })
+              .multiply(b)
+              .getAmount() ===
+            Dinero({ amount: b })
+              .multiply(a)
+              .getAmount()
+        )
+      )
+    })
+    test('should be associative', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.integer,
+          jsc.integer,
+          jsc.integer,
+          (a, b, c) =>
+            Dinero({ amount: a })
+              .multiply(b)
+              .multiply(c)
+              .getAmount() ===
+            Dinero({ amount: b })
+              .multiply(
+                Dinero({ amount: a })
+                  .multiply(c)
+                  .getAmount()
+              )
+              .getAmount()
+        )
+      )
+    })
+    test('should be distributive with integers', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.integer,
+          jsc.record({ amount: jsc.integer }),
+          jsc.record({ amount: jsc.integer }),
+          (a, b, c) =>
+            Dinero(b)
+              .add(Dinero(c))
+              .multiply(a)
+              .getAmount() ===
+            Dinero(b)
+              .multiply(a)
+              .add(Dinero(c).multiply(a))
+              .getAmount()
+        )
+      )
+    })
+    test('should round when multiplier is a non-integer', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.nat,
+          jsc.number(-1e10, 1e10),
+          (a, b) =>
+            Dinero({ amount: a })
+              .multiply(b)
+              .getAmount() -
+              a * b <
+            0.5
+        )
+      )
+    })
+  })
+  describe('#divide()', () => {
+    test('should round when divisor is a positive non-integer', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.nat,
+          jsc.number(1, 1e10),
+          (a, b) =>
+            Dinero({ amount: a })
+              .divide(b)
+              .getAmount() -
+              a / b <
+            0.5
+        )
+      )
+    })
+    test('should round when divisor is a negative non-integer', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.nat,
+          jsc.number(-1e10, -1e-10),
+          (a, b) =>
+            Dinero({ amount: a })
+              .divide(b)
+              .getAmount() -
+              a / b <
+            0.5
+        )
+      )
+    })
+  })
+})

--- a/test/property/helpers.spec.js
+++ b/test/property/helpers.spec.js
@@ -1,0 +1,13 @@
+import * as Helpers from '../../src/services/helpers'
+import jsc from 'jsverify'
+
+describe('Helpers', () => {
+  describe('#isEven', () => {
+    test('should return true for even numbers', () => {
+      jsc.assert(jsc.forall(jsc.uint8, a => Helpers.isEven(a * 2)))
+    })
+    test('should return false for odd numbers', () => {
+      jsc.assert(jsc.forall(jsc.uint8, a => !Helpers.isEven(a * 2 - 1)))
+    })
+  })
+})

--- a/test/unit/calculator.spec.js
+++ b/test/unit/calculator.spec.js
@@ -28,4 +28,21 @@ describe('Calculator', () => {
       expect(calculator.modulo(5, 2)).toBe(1)
     })
   })
+  describe('#bankersRound()', () => {
+    test('should return normal rounding for 1.4', () => {
+      expect(calculator.bankersRound(1.4)).toBe(1)
+    })
+    test('should return normal rounding for -1.4', () => {
+      expect(calculator.bankersRound(-1.4)).toBe(-1)
+    })
+    test('should return nearest even number for 1.5', () => {
+      expect(calculator.bankersRound(1.5)).toBe(2)
+    })
+    test('should return nearest even number for 2.5', () => {
+      expect(calculator.bankersRound(2.5)).toBe(2)
+    })
+    test('should return nearest even number for -2.5', () => {
+      expect(calculator.bankersRound(-2.5)).toBe(-2)
+    })
+  })
 })

--- a/test/unit/dinero.spec.js
+++ b/test/unit/dinero.spec.js
@@ -101,9 +101,21 @@ describe('Dinero', () => {
         Dinero({ amount: 400 })
           .multiply(4)
           .toObject()
-      ).toMatchObject({
-        amount: 1600
-      })
+      ).toMatchObject({ amount: 1600 })
+    })
+    test('should return a new Dinero object with an amount multiplied and rounded down', () => {
+      expect(
+        Dinero({ amount: 400 })
+          .multiply(2.001)
+          .toObject()
+      ).toMatchObject({ amount: 800 })
+    })
+    test('should return a new Dinero object with an amount multiplied and rounded up', () => {
+      expect(
+        Dinero({ amount: 400 })
+          .multiply(2.002)
+          .toObject()
+      ).toMatchObject({ amount: 801 })
     })
   })
   describe('#divide()', () => {
@@ -113,6 +125,27 @@ describe('Dinero', () => {
           .divide(4)
           .toObject()
       ).toMatchObject({ amount: 100 })
+    })
+    test('should return a new Dinero object with an amount divided and rounded down', () => {
+      expect(
+        Dinero({ amount: 400 })
+          .divide(3)
+          .toObject()
+      ).toMatchObject({ amount: 133 })
+    })
+    test('should return a new Dinero object with an amount divided and rounded up', () => {
+      expect(
+        Dinero({ amount: 400 })
+          .divide(6)
+          .toObject()
+      ).toMatchObject({ amount: 67 })
+    })
+    test('should return a new Dinero object with an amount divided and rounded to nearest even number', () => {
+      expect(
+        Dinero({ amount: 105 })
+          .divide(2)
+          .toObject()
+      ).toMatchObject({ amount: 52 })
     })
   })
   describe('#percentage()', () => {

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -18,4 +18,18 @@ describe('Helpers()', () => {
       expect(Helpers.isNumeric(Infinity)).toBe(false)
     })
   })
+  describe('#isEven()', () => {
+    test('should return true for a positive even integer', () => {
+      expect(Helpers.isEven(202)).toBe(true)
+    })
+    test('should return true for a negative even integer', () => {
+      expect(Helpers.isEven(-202)).toBe(true)
+    })
+    test('should return false for a positive odd integer', () => {
+      expect(Helpers.isEven(101)).toBe(false)
+    })
+    test('should return false for a negative odd integer', () => {
+      expect(Helpers.isEven(-101)).toBe(false)
+    })
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3829,6 +3829,15 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jsverify@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/jsverify/-/jsverify-0.8.3.tgz#02e9178e1924b5aaf959c0239af84ed5c6d0738c"
+  dependencies:
+    lazy-seq "^1.0.0"
+    rc4 "~0.1.5"
+    trampa "^1.0.0"
+    typify-parser "^1.1.0"
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -3876,6 +3885,10 @@ latest-version@^3.0.0:
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+
+lazy-seq@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lazy-seq/-/lazy-seq-1.0.0.tgz#880cb8aab256026382e02f53ec089682a74c5b6a"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -4882,6 +4895,10 @@ randomatic@^1.1.3:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+rc4@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/rc4/-/rc4-0.1.5.tgz#08c6e04a0168f6eb621c22ab6cb1151bd9f4a64d"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.6"
@@ -5890,6 +5907,10 @@ tr46@^1.0.0:
   dependencies:
     punycode "^2.1.0"
 
+trampa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trampa/-/trampa-1.0.0.tgz#5247347ac334807fa6c0000444cb91b639840ad5"
+
 traverse@~0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
@@ -5941,6 +5962,10 @@ type-check@~0.3.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typify-parser@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/typify-parser/-/typify-parser-1.1.0.tgz#ac73bfa5f25343468e2d0f3346c6117bc03d3c99"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
Use [Banker's Rounding](http://wiki.c2.com/?BankersRounding) to round intermediate calculations in `#divide` and `#multiply`. Added a few property-based tests to add some robustness to the expectations and test some edge cases.

fix #11