### PR TITLE
feat(dinero): Allow specifying a precision to store internal value

### DIFF
--- a/src/dinero.js
+++ b/src/dinero.js
@@ -59,19 +59,26 @@ const Dinero = options => {
       if (!Number.isInteger(number)) {
         throw new TypeError('You must provide an integer.')
       }
+    },
+    isValidPrecision(number) {
+      if (number < 1 || number > 15) {
+        throw new TypeError('You must provide an integer between 1 and 15.')
+      }
     }
   }
 
-  const { amount, currency } = Object.assign(
-    {},
+  const { amount, currency, precision } = Object.assign(
     {
       amount: Dinero.defaultAmount,
-      currency: Dinero.defaultCurrency
+      currency: Dinero.defaultCurrency,
+      precision: Dinero.defaultPrecision
     },
     options
   )
 
   assert.isInteger(amount)
+  assert.isInteger(precision)
+  assert.isValidPrecision(precision)
 
   const { globalLocale, globalFormat } = Dinero
 
@@ -125,6 +132,18 @@ const Dinero = options => {
      */
     getCurrency() {
       return currency
+    },
+    /**
+     * Returns the precision.
+     *
+     * @example
+     * // returns 6
+     * Dinero({ precision: 6 }).getPrecision()
+     *
+     * @return {Number}
+     */
+    getPrecision() {
+      return precision
     },
     /**
      * Returns the locale.
@@ -574,7 +593,9 @@ const Dinero = options => {
      * @return {Number}
      */
     toUnit() {
-      return calculator.divide(this.getAmount(), 100)
+      const factor = Math.pow(10, this.getPrecision())
+
+      return calculator.divide(this.getAmount(), factor)
     },
     /**
      * Returns the amount represented by this object in rounded units.

--- a/src/services/settings.js
+++ b/src/services/settings.js
@@ -15,7 +15,8 @@
  */
 export const Defaults = {
   defaultAmount: 0,
-  defaultCurrency: 'USD'
+  defaultCurrency: 'USD',
+  defaultPrecision: 2
 }
 
 /**

--- a/test/property/dinero.spec.js
+++ b/test/property/dinero.spec.js
@@ -2,6 +2,18 @@ import Dinero from '../../src/dinero'
 import jsc from 'jsverify'
 
 describe('Dinero', () => {
+  describe('precision', () => {
+    test('should return the correct amount for precision values in range', () => {
+      jsc.assert(
+        jsc.forall(
+          jsc.integer(1, 15),
+          a =>
+            Dinero({ amount: Math.pow(10, a + 1), precision: a }).toUnit() ===
+            10
+        )
+      )
+    })
+  })
   describe('#add()', () => {
     test('should be commutative', () => {
       jsc.assert(

--- a/test/unit/dinero.spec.js
+++ b/test/unit/dinero.spec.js
@@ -12,6 +12,17 @@ describe('Dinero', () => {
       expect(() => Dinero({ amount: '100' })).toThrow()
     })
   })
+  describe('precision', () => {
+    test('should return a new Dinero object with proper precision', () => {
+      expect(Dinero({ amount: 10000000, precision: 6 }).toUnit()).toBe(10)
+    })
+    test('should throw when precision less than 1', () => {
+      expect(() => Dinero({ precision: 0 })).toThrow()
+    })
+    test('should throw when precision more than 15', () => {
+      expect(() => Dinero({ precision: 16 })).toThrow()
+    })
+  })
   describe('#getAmount()', () => {
     test('should return the right amount as a number', () => {
       expect(Dinero({ amount: 500 }).getAmount()).toBe(500)
@@ -26,6 +37,14 @@ describe('Dinero', () => {
     })
     test('should return the default currency as a string when no currency is specified', () => {
       expect(Dinero().getCurrency()).toBe('USD')
+    })
+  })
+  describe('#getPrecision()', () => {
+    test('should return the right precision as a number', () => {
+      expect(Dinero({ precision: 6 }).getPrecision()).toBe(6)
+    })
+    test('should return the default precision as a number when no precision is specified', () => {
+      expect(Dinero().getPrecision()).toBe(2)
     })
   })
   describe('#getLocale()', () => {
@@ -400,8 +419,8 @@ describe('Dinero', () => {
     })
   })
   describe('#toUnit()', () => {
-    test('should return the amount divided by 100', () => {
-      expect(Dinero({ amount: 1050 }).toUnit()).toBe(10.5)
+    test('should return the amount divided by the correct precision', () => {
+      expect(Dinero({ amount: 105000, precision: 4 }).toUnit()).toBe(10.5)
     })
   })
   describe('#toRoundedUnit()', () => {


### PR DESCRIPTION
Totally naive implementation for storing the value at a higher precision. A starting point for discussion.

This immediately jumped out to me: The value and precision being stored in a single `Number` has limitations on the size of the final number we can represent. I've limited the precision to 15 here, but it's so easy to approach the `Number.MAX_SAFE_INTEGER` here with a few multiplication operations. The current implementation suffers from this, too, but it's more likely to happen at higher precision values than at the current value of `2`.

re #13