### PR TITLE
Add precision concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 coverage
 npm-shrinkwrap.json
 package-lock.json
+yarn-error.log

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Dinero({ amount: 10545, precision: 3 })
 Dinero({ amount: 1, currency: 'JPY', precision: 0 })
 ```
 
-Of course, if you're using the same currency more than once, it might be worth setting a default precision.
+If you're using the same currency more than once, it might be worth setting a default precision.
 
 ```js
 // The Iraqi dinar has up to 3 sub-units

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Dinero.js makes it easy to create, calculate and format monetary values in JavaS
 
 **Note:** The library is globally available in the docs for you to be able to test it right in the browser console.
 
-To get started, you need to create a new Dinero instance. Amounts are specified in **cents**. You can also specify an [ISO 4217 currency code][wiki:iso-4217] (default is `USD`).
+To get started, you need to create a new Dinero instance. Amounts are specified in **minor currency units** (e.g.: "cents" for the dollar). You can also specify an [ISO 4217 currency code][wiki:iso-4217] (default is `USD`).
 
 This represents €50:
 
@@ -155,6 +155,28 @@ Dinero({ amount: 500 })
   .setLocale('fr-FR')
   .add(Dinero({ amount: 500 }))
   .toFormat('$0,0')
+```
+
+By default, new Dinero objects represent monetary values with two decimal places. If you want to represent more, or if you're using a currency with a different [exponent](https://en.wikipedia.org/wiki/ISO_4217#Treatment_of_minor_currency_units_(the_%22exponent%22)), you can specify a precision.
+
+```js
+// represents $10.4545
+Dinero({ amount: 10545, precision: 3 })
+
+// The Japanese yen doesn't have sub-units
+// this represents ¥1
+Dinero({ amount: 1, currency: 'JPY', precision: 0 })
+```
+
+Of course, if you're using the same currency more than once, it might be worth setting a default precision.
+
+```js
+// The Iraqi dinar has up to 3 sub-units
+Dinero.defaultCurrency = 'IQD'
+Dinero.defaultPrecision = 3
+
+// represents IQD1
+Dinero({ amount: 1000 })
 ```
 
 This is only a preview of what you can do. Dinero.js has extensive documentation with examples for all of its methods.

--- a/src/dinero.js
+++ b/src/dinero.js
@@ -1,4 +1,5 @@
 import { Defaults, Globals } from './services/settings'
+import Static from './services/static'
 import Format from './services/format'
 import Calculator from './services/calculator'
 import {
@@ -14,41 +15,45 @@ const calculator = Calculator()
  * A Dinero object is an immutable data structure representing a specific monetary value.
  * It comes with methods for creating, parsing, manipulating, testing, transforming and formatting them.
  *
- * A Dinero object posesses:
+ * A Dinero object has:
  *
- * * An `amount`, expressed in cents.
+ * * An `amount`, expressed in minor currency units.
  * * A `currency`, expressed as an {@link https://en.wikipedia.org/wiki/ISO_4217#Active_codes ISO 4217 currency code}.
+ * * A `precision`, expressed as an integer, to represent the number of decimal places in the `amount`.
+ *   This is helpful when you want to represent fractional minor currency units (e.g.: $10.4545).
+ *   You can also use it to represent a currency with a different [exponent](https://en.wikipedia.org/wiki/ISO_4217#Treatment_of_minor_currency_units_.28the_.22exponent.22.29) than `2` (e.g.: Iraqi dinar with 1000 fils in 1 dinar (exponent of `3`), Japanese yen with no sub-units (exponent of `0`)).
  * * An optional `locale` property that affects how output strings are formatted.
  *
  * Here's an overview of the public API:
  *
- * * **Access:** {@link module:Dinero~getAmount getAmount}, {@link module:Dinero~getCurrency getCurrency} and {@link module:Dinero~getLocale getLocale}.
+ * * **Access:** {@link module:Dinero~getAmount getAmount}, {@link module:Dinero~getCurrency getCurrency}, {@link module:Dinero~getLocale getLocale} and {@link module:Dinero~getPrecision getPrecision}.
  * * **Manipulation:** {@link module:Dinero~add add}, {@link module:Dinero~subtract subtract}, {@link module:Dinero~multiply multiply}, {@link module:Dinero~divide divide}, {@link module:Dinero~percentage percentage} and {@link module:Dinero~allocate allocate}.
  * * **Testing:** {@link module:Dinero~equalsTo equalsTo}, {@link module:Dinero~lessThan lessThan}, {@link module:Dinero~lessThanOrEqual lessThanOrEqual}, {@link module:Dinero~greaterThan greaterThan}, {@link module:Dinero~greaterThanOrEqual greaterThanOrEqual}, {@link module:Dinero~isZero isZero}, {@link module:Dinero~isPositive isPositive}, {@link module:Dinero~isNegative isNegative}, {@link module:Dinero~hasCents hasCents}, {@link module:Dinero~hasSameCurrency hasSameCurrency} and {@link module:Dinero~hasSameAmount hasSameAmount}.
  * * **Configuration:** {@link module:Dinero~setLocale setLocale}.
- * * **Conversion & formatting:** {@link module:Dinero~toFormat toFormat}, {@link module:Dinero~toUnit toUnit}, {@link module:Dinero~toRoundedUnit toRoundedUnit} and {@link module:Dinero~toObject toObject}.
+ * * **Conversion & formatting:** {@link module:Dinero~toFormat toFormat}, {@link module:Dinero~toUnit toUnit}, {@link module:Dinero~toRoundedUnit toRoundedUnit}, {@link module:Dinero~toObject toObject}, {@link module:Dinero~convertPrecision convertPrecision} and {@link module:Dinero.normalizePrecision normalizePrecision}.
  *
  * @module Dinero
- * @param  {Number} [options.amount=0] - The amount in cents (as an integer).
+ * @param  {Number} [options.amount=0] - The amount in minor currency units (as an integer).
  * @param  {String} [options.currency='USD'] - An ISO 4217 currency code.
+ * @param  {String} [options.precision=2] - The number of decimal places to represent.
  *
- * @throws {TypeError} If `amount` or `Dinero.defaultAmount` is invalid.
+ * @throws {TypeError} If `amount` or `precision` is invalid.
  *
  * @return {Object}
  */
 const Dinero = options => {
-  const { amount, currency } = Object.assign(
+  const { amount, currency, precision } = Object.assign(
     {},
     {
       amount: Dinero.defaultAmount,
-      currency: Dinero.defaultCurrency
+      currency: Dinero.defaultCurrency,
+      precision: Dinero.defaultPrecision
     },
     options
   )
 
   assertInteger(amount)
-
-  const exponent = 2
+  assertInteger(precision)
 
   const {
     globalLocale,
@@ -64,11 +69,15 @@ const Dinero = options => {
   const create = function(options) {
     const obj = Object.assign(
       {},
-      Object.assign({}, { amount, currency }, options),
+      Object.assign({}, { amount, currency, precision }, options),
       Object.assign({}, { locale: this.locale }, options)
     )
     return Object.assign(
-      Dinero({ amount: obj.amount, currency: obj.currency }),
+      Dinero({
+        amount: obj.amount,
+        currency: obj.currency,
+        precision: obj.precision
+      }),
       {
         locale: obj.locale
       }
@@ -140,13 +149,53 @@ const Dinero = options => {
       return create.call(this, { locale: newLocale })
     },
     /**
+     * Returns the precision.
+     *
+     * @example
+     * // returns 3
+     * Dinero({ precision: 3 }).getPrecision()
+     *
+     * @return {Number}
+     */
+    getPrecision() {
+      return precision
+    },
+    /**
+     * Returns a new Dinero object with a new precision and a converted amount.
+     *
+     * @param {Number} newPrecision - The new precision.
+     *
+     * @example
+     * // Returns a Dinero object with precision 3 and amount 1000
+     * Dinero({ amount: 100, precision: 2 }).convertPrecision(3)
+     *
+     * @throws {TypeError} If `newPrecision` is invalid.
+     *
+     * @return {Dinero}
+     */
+    convertPrecision(newPrecision) {
+      assertInteger(newPrecision)
+      return create.call(this, {
+        amount: calculator.multiply(
+          this.getAmount(),
+          Math.pow(10, calculator.subtract(newPrecision, this.getPrecision()))
+        ),
+        precision: newPrecision
+      })
+    },
+    /**
      * Returns a new Dinero object that represents the sum of this and an other Dinero object.
+     *
+     * If Dinero objects have a different `precision`, they will be first converted to the highest.
      *
      * @param {Dinero} addend - The Dinero object to add.
      *
      * @example
      * // returns a Dinero object with amount 600
      * Dinero({ amount: 400 }).add(Dinero({ amount: 200 }))
+     * @example
+     * // returns a Dinero object with amount 144545 and precision 4
+     * Dinero({ amount: 400 }).add(Dinero({ amount: 104545, precision: 4 }))
      *
      * @throws {TypeError} If `addend` has a different currency.
      *
@@ -154,18 +203,25 @@ const Dinero = options => {
      */
     add(addend) {
       assertSameCurrency.call(this, addend)
+      const addends = Dinero.normalizePrecision([this, addend])
       return create.call(this, {
-        amount: calculator.add(this.getAmount(), addend.getAmount())
+        amount: calculator.add(addends[0].getAmount(), addends[1].getAmount()),
+        precision: addends[0].getPrecision()
       })
     },
     /**
      * Returns a new Dinero object that represents the difference of this and an other Dinero object.
+     *
+     * If Dinero objects have a different `precision`, they will be first converted to the highest.
      *
      * @param  {Dinero} subtrahend - The Dinero object to subtract.
      *
      * @example
      * // returns a Dinero object with amount 200
      * Dinero({ amount: 400 }).subtract(Dinero({ amount: 200 }))
+     * @example
+     * // returns a Dinero object with amount 64545 and precision 4
+     * Dinero({ amount: 104545, precision: 4 }).subtract(Dinero({ amount: 400 }))
      *
      * @throws {TypeError} If `subtrahend` has a different currency.
      *
@@ -173,14 +229,19 @@ const Dinero = options => {
      */
     subtract(subtrahend) {
       assertSameCurrency.call(this, subtrahend)
+      const subtrahends = Dinero.normalizePrecision([this, subtrahend])
       return create.call(this, {
-        amount: calculator.subtract(this.getAmount(), subtrahend.getAmount())
+        amount: calculator.subtract(
+          subtrahends[0].getAmount(),
+          subtrahends[1].getAmount()
+        ),
+        precision: subtrahends[0].getPrecision()
       })
     },
     /**
      * Returns a new Dinero object that represents the multiplied value by the given factor.
      *
-     * By default, fractional cents are rounded using the **half to even** rule ([banker's rounding](http://wiki.c2.com/?BankersRounding)).
+     * By default, fractional minor currency units are rounded using the **half to even** rule ([banker's rounding](http://wiki.c2.com/?BankersRounding)).
      *
      * Rounding *can* lead to accuracy issues as you chain many times. Consider a minimal amount of subsequent calculations for safer results.
      * You can also specify a different `roundingMode` to better fit your needs.
@@ -211,7 +272,7 @@ const Dinero = options => {
     /**
      * Returns a new Dinero object that represents the divided value by the given factor.
      *
-     * By default, fractional cents are rounded using the **half to even** rule ([banker's rounding](http://wiki.c2.com/?BankersRounding)).
+     * By default, fractional minor currency units are rounded using the **half to even** rule ([banker's rounding](http://wiki.c2.com/?BankersRounding)).
      *
      * Rounding *can* lead to accuracy issues as you chain many times. Consider a minimal amount of subsequent calculations for safer results.
      * You can also specify a different `roundingMode` to better fit your needs.
@@ -326,6 +387,12 @@ const Dinero = options => {
      * @example
      * // returns false
      * Dinero({ amount: 500, currency: 'USD' }).equalsTo(Dinero({ amount: 800, currency: 'EUR' }))
+     * @example
+     * // returns true
+     * Dinero({ amount: 1000, currency: 'EUR', precision: 2 }).equalsTo(Dinero({ amount: 10000, currency: 'EUR', precision: 3 }))
+     * @example
+     * // returns false
+     * Dinero({ amount: 10000, currency: 'EUR', precision: 2 }).equalsTo(Dinero({ amount: 10000, currency: 'EUR', precision: 3 }))
      *
      * @return {Boolean}
      */
@@ -343,6 +410,12 @@ const Dinero = options => {
      * @example
      * // returns false
      * Dinero({ amount: 800 }).lessThan(Dinero({ amount: 500 }))
+     * @example
+     * // returns true
+     * Dinero({ amount: 5000, precision: 3 }).lessThan(Dinero({ amount: 800 }))
+     * @example
+     * // returns false
+     * Dinero({ amount: 800 }).lessThan(Dinero({ amount: 5000, precision: 3 }))
      *
      * @throws {TypeError} If `comparator` has a different currency.
      *
@@ -350,7 +423,8 @@ const Dinero = options => {
      */
     lessThan(comparator) {
       assertSameCurrency.call(this, comparator)
-      return this.getAmount() < comparator.getAmount()
+      const comparators = Dinero.normalizePrecision([this, comparator])
+      return comparators[0].getAmount() < comparators[1].getAmount()
     },
     /**
      * Checks whether the value represented by this object is less than or equal to the other.
@@ -366,6 +440,15 @@ const Dinero = options => {
      * @example
      * // returns false
      * Dinero({ amount: 500 }).lessThanOrEqual(Dinero({ amount: 300 }))
+     * @example
+     * // returns true
+     * Dinero({ amount: 5000, precision: 3 }).lessThanOrEqual(Dinero({ amount: 800 }))
+     * @example
+     * // returns true
+     * Dinero({ amount: 5000, precision: 3 }).lessThanOrEqual(Dinero({ amount: 500 }))
+     * @example
+     * // returns false
+     * Dinero({ amount: 800 }).lessThanOrEqual(Dinero({ amount: 5000, precision: 3 }))
      *
      * @throws {TypeError} If `comparator` has a different currency.
      *
@@ -373,7 +456,8 @@ const Dinero = options => {
      */
     lessThanOrEqual(comparator) {
       assertSameCurrency.call(this, comparator)
-      return this.getAmount() <= comparator.getAmount()
+      const comparators = Dinero.normalizePrecision([this, comparator])
+      return comparators[0].getAmount() <= comparators[1].getAmount()
     },
     /**
      * Checks whether the value represented by this object is greater than the other.
@@ -386,6 +470,12 @@ const Dinero = options => {
      * @example
      * // returns true
      * Dinero({ amount: 800 }).greaterThan(Dinero({ amount: 500 }))
+     * @example
+     * // returns true
+     * Dinero({ amount: 800 }).greaterThan(Dinero({ amount: 5000, precision: 3 }))
+     * @example
+     * // returns false
+     * Dinero({ amount: 5000, precision: 3 }).greaterThan(Dinero({ amount: 800 }))
      *
      * @throws {TypeError} If `comparator` has a different currency.
      *
@@ -393,7 +483,8 @@ const Dinero = options => {
      */
     greaterThan(comparator) {
       assertSameCurrency.call(this, comparator)
-      return this.getAmount() > comparator.getAmount()
+      const comparators = Dinero.normalizePrecision([this, comparator])
+      return comparators[0].getAmount() > comparators[1].getAmount()
     },
     /**
      * Checks whether the value represented by this object is greater than or equal to the other.
@@ -409,6 +500,15 @@ const Dinero = options => {
      * @example
      * // returns false
      * Dinero({ amount: 500 }).greaterThanOrEqual(Dinero({ amount: 800 }))
+     * @example
+     * // returns true
+     * Dinero({ amount: 800 }).greaterThanOrEqual(Dinero({ amount: 5000, precision: 3 }))
+     * @example
+     * // returns true
+     * Dinero({ amount: 500 }).greaterThanOrEqual(Dinero({ amount: 5000, precision: 3 }))
+     * @example
+     * // returns false
+     * Dinero({ amount: 5000, precision: 3 }).greaterThanOrEqual(Dinero({ amount: 800 }))
      *
      * @throws {TypeError} If `comparator` has a different currency.
      *
@@ -416,7 +516,8 @@ const Dinero = options => {
      */
     greaterThanOrEqual(comparator) {
       assertSameCurrency.call(this, comparator)
-      return this.getAmount() >= comparator.getAmount()
+      const comparators = Dinero.normalizePrecision([this, comparator])
+      return comparators[0].getAmount() >= comparators[1].getAmount()
     },
     /**
      * Checks if the value represented by this object is zero.
@@ -470,7 +571,7 @@ const Dinero = options => {
       return this.getAmount() < 0
     },
     /**
-     * Checks if this has cents.
+     * Checks if this has minor currency units.
      *
      * @example
      * // returns false
@@ -482,7 +583,7 @@ const Dinero = options => {
      * @return {Boolean}
      */
     hasCents() {
-      return calculator.modulo(this.getAmount(), Math.pow(10, exponent)) !== 0
+      return calculator.modulo(this.getAmount(), Math.pow(10, precision)) !== 0
     },
     /**
      * Checks whether the currency represented by this object equals to the other.
@@ -512,11 +613,18 @@ const Dinero = options => {
      * @example
      * // returns false
      * Dinero({ amount: 2000, currency: 'EUR' }).hasSameAmount(Dinero({ amount: 1000, currency: 'EUR' }))
+     * @example
+     * // returns true
+     * Dinero({ amount: 1000, currency: 'EUR', precision: 2 }).hasSameAmount(Dinero({ amount: 10000, precision: 3 }))
+     * @example
+     * // returns false
+     * Dinero({ amount: 10000, currency: 'EUR', precision: 2 }).hasSameAmount(Dinero({ amount: 10000, precision: 3 }))
      *
      * @return {Boolean}
      */
     hasSameAmount(comparator) {
-      return this.getAmount() === comparator.getAmount()
+      const comparators = Dinero.normalizePrecision([this, comparator])
+      return comparators[0].getAmount() === comparators[1].getAmount()
     },
     /**
      * Returns this object formatted as a string.
@@ -539,7 +647,7 @@ const Dinero = options => {
      * If you want to display the object in a custom way, either use {@link module:Dinero~getAmount getAmount}, {@link module:Dinero~toUnit toUnit} or {@link module:Dinero~toRoundedUnit toRoundedUnit} and manipulate the output string as you wish.
      *
      * {@link module:Dinero~toFormat toFormat} is syntactic sugar over JavaScript's native `Number.prototype.toLocaleString` method, which you can use directly:
-     * `Dinero().toRoundedUnit(precision).toLocaleString(locale, options)`.
+     * `Dinero().toRoundedUnit(digits, roundingMode).toLocaleString(locale, options)`.
      *
      * By default, amounts are rounded using the **half away from zero** rule ([commercial rounding](https://en.wikipedia.org/wiki/Rounding#Round_half_away_from_zero)).
      * You can also specify a different `roundingMode` to better fit your needs.
@@ -585,11 +693,14 @@ const Dinero = options => {
      * @example
      * // returns 10.5
      * Dinero({ amount: 1050 }).toUnit()
+     * @example
+     * // returns 10.545
+     * Dinero({ amount: 10545, precision: 3 }).toUnit()
      *
      * @return {Number}
      */
     toUnit() {
-      return calculator.divide(this.getAmount(), Math.pow(10, exponent))
+      return calculator.divide(this.getAmount(), Math.pow(10, precision))
     },
     /**
      * Returns the amount represented by this object in rounded units.
@@ -604,17 +715,17 @@ const Dinero = options => {
      * // returns 10
      * Dinero({ amount: 1050 }).toRoundedUnit(0, 'HALF_EVEN')
      *
-     * @param  {Number} precision - The number of fraction digits to round to.
+     * @param  {Number} digits - The number of fraction digits to round to.
      * @param  {String} [roundingMode='HALF_AWAY_FROM_ZERO'] - The rounding mode to use: `'HALF_ODD'`, `'HALF_EVEN'`, `'HALF_UP'`, `'HALF_DOWN'`, `'HALF_TOWARDS_ZERO'` or `'HALF_AWAY_FROM_ZERO'`.
      *
      * @return {Number}
      */
-    toRoundedUnit(precision, roundingMode = globalFormatRoundingMode) {
-      const factor = Math.pow(10, precision)
+    toRoundedUnit(digits, roundingMode = globalFormatRoundingMode) {
+      const factor = Math.pow(10, digits)
       return calculator.divide(
         calculator.round(
           calculator.multiply(
-            calculator.divide(this.getAmount(), Math.pow(10, exponent)),
+            calculator.divide(this.getAmount(), Math.pow(10, precision)),
             factor
           ),
           roundingMode
@@ -626,18 +737,19 @@ const Dinero = options => {
      * Return the object's data as an object literal.
      *
      * @example
-     * // returns { amount: 500, currency: 'EUR' }
-     * Dinero({ amount: 500, currency: 'EUR' }).toObject()
+     * // returns { amount: 500, currency: 'EUR', precision: 2 }
+     * Dinero({ amount: 500, currency: 'EUR', precision: 2 }).toObject()
      *
      * @return {Object}
      */
     toObject() {
       return {
         amount,
-        currency
+        currency,
+        precision
       }
     }
   }
 }
 
-export default Object.assign(Dinero, Defaults, Globals)
+export default Object.assign(Dinero, Defaults, Globals, Static)

--- a/src/services/settings.js
+++ b/src/services/settings.js
@@ -6,6 +6,7 @@
  *
  * @property {Number} defaultAmount - The default amount for new Dinero objects (see {@link module:Dinero Dinero} for format).
  * @property {String} defaultCurrency - The default currency for new Dinero objects (see {@link module:Dinero Dinero} for format).
+ * @property {Number} defaultPrecision - The default precision for new Dinero objects (see {@link module:Dinero Dinero} for format).
  *
  * @example
  * // Will set currency to 'EUR' for all Dinero objects.
@@ -15,7 +16,8 @@
  */
 export const Defaults = {
   defaultAmount: 0,
-  defaultCurrency: 'USD'
+  defaultCurrency: 'USD',
+  defaultPrecision: 2
 }
 
 /**

--- a/src/services/static.js
+++ b/src/services/static.js
@@ -1,0 +1,38 @@
+/**
+ * Static methods for Dinero.
+ * @ignore
+ *
+ * @type {Object}
+ */
+export default {
+  /**
+   * Returns an array of Dinero objects, normalized to the same precision (the highest).
+   *
+   * @memberof module:Dinero
+   * @method
+   *
+   * @param {Dinero[]} objects - An array of Dinero objects
+   *
+   * @example
+   * // returns an array of Dinero objects
+   * // both with a precision of 3
+   * // and an amount of 1000
+   * Dinero.normalizePrecision([
+   *   Dinero({ amount: 100, precision: 2 }),
+   *   Dinero({ amount: 1000, precision: 3 })
+   * ])
+   *
+   * @return {Dinero[]}
+   */
+  normalizePrecision(objects) {
+    const highestPrecision = objects.reduce((a, b) =>
+      Math.max(a.getPrecision(), b.getPrecision())
+    )
+    return objects.map(
+      object =>
+        object.getPrecision() !== highestPrecision
+          ? object.convertPrecision(highestPrecision)
+          : object
+    )
+  }
+}


### PR DESCRIPTION
This PR adds the `precision` concept to the library (as discussed in #13). This allows user to specify how many decimal places their amount represents, so they can have more precise Dinero objects. This also provides a way to circumvent the problem raised in #9 (but this will be fixed in v2).