### PR TITLE
feat(dinero.js): implement toJSON() to serialize output of Dinero object

### DIFF
--- a/src/dinero.js
+++ b/src/dinero.js
@@ -817,6 +817,39 @@ const Dinero = options => {
       })
     },
     /**
+     * Serialize this object as a string.
+     *
+     * The string output returns exactly the same string as {@link module:Dinero~toFormat toFormat} without any arguments.
+     * You can change the default formatting by setting the {@link Globals global API parameters}
+     *
+     * @example
+     * // returns $2,000
+     * Dinero.globalFormat = '$0,0'
+     * JSON.stringify(Dinero({ amount: 200000 }))
+     * @example
+     * // returns €50.5
+     * Dinero.defaultCurrency = 'EUR'
+     * Dinero.globalFormat = '$0,0.0'
+     * JSON.stringify(Dinero({ amount: 5050}))
+     * @example
+     * // returns 100 euros
+     * Dinero.globalFormat = '0,0 dollar'
+     * JSON.stringify(Dinero({ amount: 10000, currency: 'EUR' }).setLocale('fr-FR'))
+     * @example
+     * // returns 2000
+     * JSON.stringify(Dinero({ amount: 200000, currency: 'EUR' }))
+     * @example
+     * // returns $10
+     * Dinero.globalFormatRoundingMode = 'HALF_EVEN'
+     * Dinero.globalFormat = '$0'
+     * JSON.stringify(Dinero({ amount: 1050 }))
+     *
+     * @return {String}
+     */
+    toJSON() {
+      return this.toFormat()
+    },
+    /**
      * Returns the amount represented by this object in units.
      *
      * @example

--- a/test/unit/dinero.spec.js
+++ b/test/unit/dinero.spec.js
@@ -635,6 +635,73 @@ describe('Dinero', () => {
       Dinero.globalFormat = '$0,0.00'
     })
   })
+  describe('#toJSON', () => {
+    test('should return the properly formatted amount (default)', () => {
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe(
+        '€2,000.00'
+      )
+    })
+    test('should return the properly formatted amount (one fraction digit)', () => {
+      Dinero.globalFormat = '0.0'
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe(
+        '2000.0'
+      )
+    })
+    test('should return the properly formatted amount (one fraction digit, rounded)', () => {
+      Dinero.globalFormat = '0.0'
+      expect(Dinero({ amount: 1155, currency: 'EUR' }).toJSON()).toBe('11.6')
+    })
+    test('should return the properly formatted amount (use grouping)', () => {
+      Dinero.globalFormat = '0,0'
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe('2,000')
+    })
+    test('should return the properly formatted amount (use grouping, two fraction digits)', () => {
+      Dinero.globalFormat = '0,0.00'
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe(
+        '2,000.00'
+      )
+    })
+    test('should return the properly formatted amount (currency symbol)', () => {
+      Dinero.globalFormat = '$0'
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe('€2000')
+    })
+    test('should return the properly formatted amount (currency symbol, one fraction unit)', () => {
+      Dinero.globalFormat = '$0.0'
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe(
+        '€2000.0'
+      )
+    })
+    test('should return the properly formatted amount (currency symbol, use grouping)', () => {
+      Dinero.globalFormat = '$0,0'
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe(
+        '€2,000'
+      )
+    })
+    test('should return the properly formatted amount, (currency symbol, use grouping, two fraction digits)', () => {
+      Dinero.globalFormat = '$0,0.00'
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe(
+        '€2,000.00'
+      )
+    })
+    test('should return the properly formatted amount, (currency code, use grouping, two fraction digits)', () => {
+      Dinero.globalFormat = 'USD0,0.00'
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe(
+        'EUR2,000.00'
+      )
+    })
+    test('should return the properly formatted amount, (currency name, use grouping, two fraction digits)', () => {
+      Dinero.globalFormat = '0,0.00 dollar'
+      expect(Dinero({ amount: 200000, currency: 'EUR' }).toJSON()).toBe(
+        '2,000.00 euros'
+      )
+    })
+    test('should return the initial format when global format is redefined', () => {
+      Dinero.globalFormat = '$0.00'
+      const price = Dinero()
+      expect(price.toJSON()).toBe('$0.00')
+      Dinero.globalFormat = '$0,0.00'
+    })
+  })
   describe('#toUnit', () => {
     test('should return the amount divided by 100', () => {
       expect(Dinero({ amount: 1050 }).toUnit()).toBe(10.5)


### PR DESCRIPTION
Implement toJSON() so that calls to JSON.stringify(Dinero()) will return a string. See #22

#22