### PR TITLE
Update to fix provided command to build dist files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ You can make sure your environment is able to test and build by running the foll
 
 ```sh
 $ npm test  # for unit tests
-$ npm build # to build dist files
+$ npm run build # to build dist files
 ```
 
 If both commands succeed, you're good to go! 👍


### PR DESCRIPTION
Replaced `npm build` with `npm run build`. It previously didn't work due to the existing [npm build command](https://docs.npmjs.com/cli/build.html).

Sorry if I have gone about this the wrong way, hopefully this is a welcome change! :)