### PR TITLE
Update to fix provided command to build dist files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ You can make sure your environment is able to test and build by running the foll
 
 ```sh
 $ npm test  # for unit tests
-$ npm build # to build dist files
+$ npm run build # to build dist files
 ```
 
 If both commands succeed, you're good to go! 👍

--- a/docs/index.html
+++ b/docs/index.html
@@ -176,7 +176,7 @@ Dinero({ amount: 500 })
   .setLocale('fr-FR')
   .add(Dinero({ amount: 500 }))
   .toFormat('$0,0')</code></pre><p>By default, new Dinero objects represent monetary values with two decimal places. If you want to represent more, or if you're using a currency with a different <a href="https://en.wikipedia.org/wiki/ISO_4217#Treatment_of_minor_currency_units_(the_%22exponent%22">exponent</a>), you can specify a precision.</p>
-<pre class="prettyprint source lang-js"><code>// represents $10.4545
+<pre class="prettyprint source lang-js"><code>// represents $10.545
 Dinero({ amount: 10545, precision: 3 })
 
 // The Japanese yen doesn't have sub-units


### PR DESCRIPTION
Replaced `npm build` with `npm run build`. It previously didn't work due to the existing [npm build command](https://docs.npmjs.com/cli/build.html).

Sorry if I have gone about this the wrong way, hopefully this is a welcome change! :)