### PR TITLE
fix(dinero#convertPrecision): Add rounding to convertPrecision

### DIFF
--- a/src/dinero.js
+++ b/src/dinero.js
@@ -170,7 +170,14 @@ const Dinero = options => {
     /**
      * Returns a new Dinero object with a new precision and a converted amount.
      *
+     * By default, fractional minor currency units are rounded using the **half to even** rule ([banker's rounding](http://wiki.c2.com/?BankersRounding)).
+     * This can be necessary when you need to convert objects to a smaller precision.
+     *
+     * Rounding *can* lead to accuracy issues as you chain many times. Consider a minimal amount of subsequent conversions for safer results.
+     * You can also specify a different `roundingMode` to better fit your needs.
+     *
      * @param {Number} newPrecision - The new precision.
+     * @param {String} [roundingMode='HALF_EVEN'] - The rounding mode to use: `'HALF_ODD'`, `'HALF_EVEN'`, `'HALF_UP'`, `'HALF_DOWN'`, `'HALF_TOWARDS_ZERO'` or `'HALF_AWAY_FROM_ZERO'`.
      *
      * @example
      * // Returns a Dinero object with precision 3 and amount 1000
@@ -180,12 +187,15 @@ const Dinero = options => {
      *
      * @return {Dinero}
      */
-    convertPrecision(newPrecision) {
+    convertPrecision(newPrecision, roundingMode = globalFormatRoundingMode) {
       assertInteger(newPrecision)
       return create.call(this, {
-        amount: calculator.multiply(
-          this.getAmount(),
-          Math.pow(10, calculator.subtract(newPrecision, this.getPrecision()))
+        amount: calculator.round(
+          calculator.multiply(
+            this.getAmount(),
+            Math.pow(10, calculator.subtract(newPrecision, this.getPrecision()))
+          ),
+          roundingMode
         ),
         precision: newPrecision
       })

--- a/test/unit/dinero.spec.js
+++ b/test/unit/dinero.spec.js
@@ -107,6 +107,13 @@ describe('Dinero', () => {
           .toObject()
       ).toMatchObject({ amount: 50000, precision: 4 })
     })
+    test('should return a new Dinero object with a new precision and a converted rounded amount', () => {
+      expect(
+        Dinero({ amount: 14270, precision: 2 })
+          .convertPrecision(0)
+          .toObject()
+      ).toMatchObject({ amount: 143, precision: 0 })
+    })
     test('should throw when new precision is invalid', () => {
       expect(() =>
         Dinero({ amount: 500, precision: 2 })


### PR DESCRIPTION
Round converted amount in case converting to a smaller precision creates a float

fix #53

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Compliance

<!-- Is your PR compliant with the contributing guidelines of this project? Make sure you can check all boxes: -->

- [x] My change isn't breaking (it doesn't cause existing functionality to change).
- [x] I have read the [CONTRIBUTING](https://github.com/sarahdayan/dinero.js/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the coding style of this project.
- [x] I have properly formatted my commit messages with [cz-cli](https://github.com/commitizen/cz-cli), or manually, following the [Angular Commit Messages Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] I have updated the documentation accordingly, or my changes doesn't require documentation changes.
- [x] I have added tests to cover my changes, or my changes doesn't require new tests.
- [x] All new and existing tests pass.
