### PR TITLE
docs(readme): Fix semantic-release badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
   <a href="https://coveralls.io/github/sarahdayan/dinero.js?branch=master">
     <img alt="Coverage Status" src="https://img.shields.io/coveralls/github/sarahdayan/dinero.js.svg?branch=master" />
   </a>
-  <a href="https://github.com/semantic-release/semantic-release
-  [semantic-release-badge]: https://img.shields.io/badge/">
+  <a href="https://github.com/semantic-release/semantic-release">
     <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg" />
   </a>
 </div>


### PR DESCRIPTION
Fixes a link inside the semantic-release badge, left from its markdown code probably.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

(Or “Docs fix” — I wonder if it should have its own checkbox, or the “bug fix” should suffice?)

## Compliance

- [x] My change isn't breaking (it doesn't cause existing functionality to change).
- [x] I have read the [CONTRIBUTING](https://github.com/sarahdayan/dinero.js/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the coding style of this project.
- [x] I have properly formatted my commit messages with [cz-cli](https://github.com/commitizen/cz-cli), or manually, following the [Angular Commit Messages Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] I have updated the documentation accordingly, or my changes doesn't require documentation changes.
- [x] I have added tests to cover my changes, or my changes doesn't require new tests.
- [x] All new and existing tests pass.
